### PR TITLE
Coordinated shutdown

### DIFF
--- a/Akka.Cluster.Discovery.sln
+++ b/Akka.Cluster.Discovery.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27004.2009
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "plugins", "plugins", "{47DDFCDE-4E37-4578-AE1C-A489DC5D9D65}"
 EndProject
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Cluster.Discovery", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleApp", "samples\SampleApp\SampleApp.csproj", "{FCEB357F-FDBA-44CC-93DA-22B8CD338FAA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Cluster.Discovery.Consul.Tests", "test\Akka.Cluster.Discovery.Consul.Tests\Akka.Cluster.Discovery.Consul.Tests.csproj", "{5A97B600-A5F6-41B6-B679-36CC00A02074}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{FCEB357F-FDBA-44CC-93DA-22B8CD338FAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FCEB357F-FDBA-44CC-93DA-22B8CD338FAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FCEB357F-FDBA-44CC-93DA-22B8CD338FAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A97B600-A5F6-41B6-B679-36CC00A02074}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A97B600-A5F6-41B6-B679-36CC00A02074}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A97B600-A5F6-41B6-B679-36CC00A02074}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A97B600-A5F6-41B6-B679-36CC00A02074}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,6 +59,7 @@ Global
 		{7D6FC91C-EDD3-4EFF-A11E-8A0B947618C6} = {47DDFCDE-4E37-4578-AE1C-A489DC5D9D65}
 		{1797672F-B131-417D-A795-C610412F5F7E} = {47DDFCDE-4E37-4578-AE1C-A489DC5D9D65}
 		{FCEB357F-FDBA-44CC-93DA-22B8CD338FAA} = {13582145-1B13-4463-B3D8-A2E5F3901EA2}
+		{5A97B600-A5F6-41B6-B679-36CC00A02074} = {E6467853-363A-4A5E-8FD5-E56A95F5308D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {60AE04FF-5CD9-4124-990A-27696C9C181F}

--- a/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
@@ -95,6 +95,8 @@ namespace Akka.Cluster.Discovery.Consul
         {
             var id = ServiceId(node.Address);
             await consul.Agent.ServiceDeregister(id);
+
+            Log.Info("Deregistered node [{0}] from consul.", node);
         }
 
         protected override async Task MarkAsAliveAsync(MemberEntry node)

--- a/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
@@ -91,6 +91,12 @@ namespace Akka.Cluster.Discovery.Consul
             Log.Info("Registered node [{0}] as consul service [{1}] (TTL: {2})", node, id, settings.AliveInterval);
         }
 
+        protected override async Task DeregisterNodeAsync(MemberEntry node)
+        {
+            var id = ServiceId(node.Address);
+            await consul.Agent.ServiceDeregister(id);
+        }
+
         protected override async Task MarkAsAliveAsync(MemberEntry node)
         {
             var addr = node.Address;

--- a/src/Akka.Cluster.Discovery/reference.conf
+++ b/src/Akka.Cluster.Discovery/reference.conf
@@ -45,6 +45,6 @@ akka.cluster.discovery {
 		token = ""
 
 		# Timeout for a Consul client connection requests.
-		wait-time = <optional time>
+		wait-time = 5s
 	}
 }

--- a/test/Akka.Cluster.Discovery.Consul.Tests/Akka.Cluster.Discovery.Consul.Tests.csproj
+++ b/test/Akka.Cluster.Discovery.Consul.Tests/Akka.Cluster.Discovery.Consul.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Akka.Cluster.TestKit" Version="1.3.2" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.2" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Akka.Cluster.Discovery.Consul\Akka.Cluster.Discovery.Consul.csproj" />
+    <ProjectReference Include="..\..\src\Akka.Cluster.Discovery\Akka.Cluster.Discovery.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR adds interop between cluster discovery and coordinated shutdown - upon ClusterLeave phase discovery service will try to deregister itself gracefully. This will make reaching the convergence on 3rd party service (like Consul) easier, since it's not necessary for it to recognize that node was dead, it can be informed about node leaving the cluster instead.