### PR TITLE
TTL frequency

### DIFF
--- a/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
@@ -79,7 +79,7 @@ namespace Akka.Cluster.Discovery.Consul
                 Port = node.Address.Port.Value,
                 Check = new AgentServiceCheck
                 {
-                    TTL = settings.AliveInterval,
+                    TTL = new TimeSpan(settings.AliveInterval.Ticks * 2),
                     // deregister after 3 activity turns failed
                     DeregisterCriticalServiceAfter = settings.AliveTimeout,
                 }

--- a/src/Akka.Cluster.Discovery/ClusterDiscoverySettings.cs
+++ b/src/Akka.Cluster.Discovery/ClusterDiscoverySettings.cs
@@ -9,7 +9,7 @@ namespace Akka.Cluster.Discovery
         /// <summary>
         /// Default value of a <see cref="AliveInterval"/>: 5 seconds.
         /// </summary>
-        public static readonly TimeSpan DefaultAliveInterval = TimeSpan.FromSeconds(10);
+        public static readonly TimeSpan DefaultAliveInterval = TimeSpan.FromSeconds(5);
 
         /// <summary>
         /// Default value of <see cref="AliveTimeout"/>: 1 minute.

--- a/src/Akka.Cluster.Discovery/ClusterDiscoverySettings.cs
+++ b/src/Akka.Cluster.Discovery/ClusterDiscoverySettings.cs
@@ -69,6 +69,11 @@ namespace Akka.Cluster.Discovery
             TimeSpan refreshInterval,
             int joinRetries)
         {
+            if (aliveInterval.Ticks * 3 > aliveTimeout.Ticks) throw new ArgumentException("alive-interval should be at least 3 times shorter than alive-timeout", nameof(aliveInterval));
+            if (aliveTimeout == TimeSpan.Zero) throw new ArgumentException("alive-timeout cannot be 0", nameof(aliveTimeout));
+            if (refreshInterval == TimeSpan.Zero) throw new ArgumentException("refresh-interval cannot be 0", nameof(refreshInterval));
+            if (joinRetries == 0) throw new ArgumentException("join-retries must be possitive value", nameof(joinRetries));
+
             AliveInterval = aliveInterval;
             AliveTimeout = aliveTimeout;
             RefreshInterval = refreshInterval;

--- a/src/Akka.Cluster.Discovery/DiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery/DiscoveryService.cs
@@ -190,8 +190,9 @@ namespace Akka.Cluster.Discovery
             await RegisterNodeAsync(Entry);
             await MarkAsAliveAsync(Entry);
 
-            aliveTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(settings.AliveInterval, settings.AliveInterval, Self,
-                    new Alive(Entry.Address), ActorRefs.NoSender);
+            // while we set service TTL to AliveInterval, we want to actually ping faster to be sure we won't trigger TTL guard by accident
+            var interval = new TimeSpan(settings.AliveInterval.Ticks / 2);
+            aliveTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(interval, interval, Self, new Alive(Entry.Address), ActorRefs.NoSender);
 
             if (settings.RefreshInterval != TimeSpan.Zero)
             {

--- a/src/Akka.Cluster.Discovery/DiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery/DiscoveryService.cs
@@ -190,9 +190,8 @@ namespace Akka.Cluster.Discovery
             await RegisterNodeAsync(Entry);
             await MarkAsAliveAsync(Entry);
 
-            // while we set service TTL to AliveInterval, we want to actually ping faster to be sure we won't trigger TTL guard by accident
-            var interval = new TimeSpan(settings.AliveInterval.Ticks / 2);
-            aliveTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(interval, interval, Self, new Alive(Entry.Address), ActorRefs.NoSender);
+            aliveTask = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(settings.AliveInterval, settings.AliveInterval, Self,
+                    new Alive(Entry.Address), ActorRefs.NoSender);
 
             if (settings.RefreshInterval != TimeSpan.Zero)
             {

--- a/src/Akka.Cluster.Discovery/LockingDiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery/LockingDiscoveryService.cs
@@ -109,12 +109,17 @@ namespace Akka.Cluster.Discovery
             TimeSpan lockRetryInterval) 
             : base(aliveInterval, aliveTimeout, refreshInterval, joinRetries)
         {
+            if (lockRetryInterval == TimeSpan.Zero) throw new ArgumentException("lock-retry-interval cannot be 0", nameof(lockRetryInterval));
+
             LockRetryInterval = lockRetryInterval;
         }
 
         public LockingClusterDiscoverySettings(Config config) : base(config)
         {
-            LockRetryInterval = config.GetTimeSpan("lock-retry-interval", DefaultLockRetryInterval);
+            var lockRetryInterval = config.GetTimeSpan("lock-retry-interval", DefaultLockRetryInterval);
+            if (lockRetryInterval == TimeSpan.Zero) throw new ArgumentException("lock-retry-interval cannot be 0", nameof(lockRetryInterval));
+
+            LockRetryInterval = lockRetryInterval;
         }
     }
 }

--- a/src/Akka.Cluster.Discovery/reference.conf
+++ b/src/Akka.Cluster.Discovery/reference.conf
@@ -15,7 +15,7 @@ akka.cluster.discovery {
 
 		# Time interval in which a `alive` signal will be send by a discovery service
 		# to fit the external service TTL (time to live) expectations. 
-		alive-interval = 10s
+		alive-interval = 5s
 
 		# Time to live given for a discovery service to be correctly acknowledged as
 		# alive by external monitoring service. It must be higher than `alive-interval`. 


### PR DESCRIPTION
1. Changed Consul health check TTL to be 2 * `AliveInterval` used for sending health checks.
2. Reduced default `AliveInterval` from 10s to 5s.
3. Added guards in configuration classes to avoid wrong config.
4. Added DiscoveryService stop on node being stopped - previously even thou current node has left the cluster, discovery service was still alive and trying to send healthchecks.