### PR TITLE
service-check-ttl + custom dispatcher config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ akka.cluster.discovery {
 		# used by the cluster discovery plugin.
 		class = "Akka.Cluster.Discovery.Consul.ConsulDiscoveryService, Akka.Cluster.Discovery.Consul"
 
+		# Define a dispatcher type used by discovery service actor.
+		dispatcher = "akka.actor.default-dispatcher"
+
 		# Time interval in which a `alive` signal will be send by a discovery service
 		# to fit the external service TTL (time to live) expectations. 
 		alive-interval = 5s
@@ -91,7 +94,11 @@ akka.cluster.discovery {
 		token = ""
 
 		# Timeout for a Consul client connection requests.
-		wait-time = <optional time>
+		wait-time = 5s
+
+		# A timeout configured for consul to mark a time to live given for a node
+		# before it will be marked as unhealthy. Must be greater than `alive-interval` and less than `alive-timeout`.
+		service-check-ttl = 15s
 	}
 }
 ```

--- a/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
@@ -79,8 +79,7 @@ namespace Akka.Cluster.Discovery.Consul
                 Port = node.Address.Port.Value,
                 Check = new AgentServiceCheck
                 {
-                    TTL = new TimeSpan(settings.AliveInterval.Ticks * 2),
-                    // deregister after 3 activity turns failed
+                    TTL = settings.ServiceCheckTtl,
                     DeregisterCriticalServiceAfter = settings.AliveTimeout,
                 }
             };

--- a/src/Akka.Cluster.Discovery.Consul/ConsulSettings.cs
+++ b/src/Akka.Cluster.Discovery.Consul/ConsulSettings.cs
@@ -20,14 +20,20 @@ namespace Akka.Cluster.Discovery.Consul
             Datacenter = config.GetString("datacenter");
             Token = config.GetString("token");
             WaitTime = !config.HasPath("wait-time") ? default(TimeSpan?) : config.GetTimeSpan("wait-time");
+
+            var serviceCheckTtl = config.GetTimeSpan("service-check-ttl", new TimeSpan(this.AliveInterval.Ticks * 3));
+            if (serviceCheckTtl < AliveInterval || serviceCheckTtl > AliveTimeout) throw new ArgumentException("`akka.cluster.discovery.consul.service-check-ttl` must greater than `akka.cluster.discovery.consul.alive-interval` and less than `akka.cluster.discovery.consul.alive-timeout`");
+
+            ServiceCheckTtl = serviceCheckTtl;
         }
 
-        public ConsulSettings()
+        public ConsulSettings() : base()
         {
             ListenerUrl = new Uri("http://127.0.0.1:8500");
             Datacenter = null;
             Token = null;
             WaitTime = null;
+            ServiceCheckTtl = new TimeSpan(this.AliveInterval.Ticks * 3);
         }
 
         public ConsulSettings(Uri listenerUrl,
@@ -38,13 +44,17 @@ namespace Akka.Cluster.Discovery.Consul
             TimeSpan aliveTimeout, 
             TimeSpan refreshInterval,
             int joinRetries, 
-            TimeSpan lockRetryInterval) 
+            TimeSpan lockRetryInterval,
+            TimeSpan serviceCheckTtl) 
             : base(aliveInterval, aliveTimeout, refreshInterval, joinRetries, lockRetryInterval)
         {
+            if (serviceCheckTtl < AliveInterval || serviceCheckTtl > AliveTimeout) throw new ArgumentException("serviceCheckTtl must greater than aliveInterval and less than aliveTimeout", nameof(serviceCheckTtl));
+
             ListenerUrl = listenerUrl;
             Datacenter = datacenter;
             Token = token;
             WaitTime = waitTime;
+            ServiceCheckTtl = serviceCheckTtl;
         }
 
         /// <summary>
@@ -66,5 +76,11 @@ namespace Akka.Cluster.Discovery.Consul
         /// (Optional) Timeout for consul client connection requests.
         /// </summary>
         public TimeSpan? WaitTime { get; }
+
+        /// <summary>
+        /// A timeout configured for consul to mark a time to live given for a node before it will be 
+        /// marked as unhealthy. Must be greater than <see cref="AliveInterval"/> and less than <see cref="AliveTimeout"/>.
+        /// </summary>
+        public TimeSpan ServiceCheckTtl { get; }
     }
 }

--- a/src/Akka.Cluster.Discovery/ClusterDiscovery.cs
+++ b/src/Akka.Cluster.Discovery/ClusterDiscovery.cs
@@ -94,23 +94,24 @@ namespace Akka.Cluster.Discovery
             var config = system.Settings.Config.GetConfig("akka.cluster.discovery");
             var providerConfig = system.Settings.Config.GetConfig(config.GetString("provider"));
             var providerType = Type.GetType(providerConfig.GetString("class"), throwOnError: true);
+            var dispatcher = providerConfig.GetString("dispatcher", Dispatch.Dispatchers.DefaultDispatcherId);
             var name = config.GetString("provider-name");
 
             if (!typeof(ActorBase).IsAssignableFrom(providerType))
                 throw new ArgumentException($"Cluster discovery provider of type [{providerType}] must be an actor.");
 
-            DiscoveryService = CreateDiscoveryService(system, providerType, providerConfig, name);
+            DiscoveryService = CreateDiscoveryService(system, providerType, providerConfig, dispatcher, name);
         }
 
-        private IActorRef CreateDiscoveryService(ExtendedActorSystem system, Type type, Config config, string name)
+        private IActorRef CreateDiscoveryService(ExtendedActorSystem system, Type type, Config config, string dispatcher, string name)
         {
             try
             {
-                return system.SystemActorOf(Props.Create(type, config), name);
+                return system.SystemActorOf(Props.Create(type, config).WithDispatcher(dispatcher), name);
             }
             catch (Exception)
             {
-                return system.SystemActorOf(Props.Create(type), name);
+                return system.SystemActorOf(Props.Create(type).WithDispatcher(dispatcher), name);
             }
         }
     }

--- a/src/Akka.Cluster.Discovery/reference.conf
+++ b/src/Akka.Cluster.Discovery/reference.conf
@@ -43,8 +43,12 @@ akka.cluster.discovery {
 
 		# A Consul token.
 		token = ""
+		
+		# A timeout configured for consul to mark a time to live given for a node
+		# before it will be marked as unhealthy. Must be greater than `alive-interval` and less than `alive-timeout`.
+		service-check-ttl = 15s
 
 		# Timeout for a Consul client connection requests.
-		wait-time = 5s
+		#wait-time = <optional value>
 	}
 }


### PR DESCRIPTION
This PR introduces 2 new settings:

1. `akka.cluster.discovery.consul.service-check-ttl` - it allows to manually set a consul agent service check TTL. By default it's 3 * `akka.cluster.discovery.consul.alive-interval`, and must be smaller than alive-timeout.
2. `akka.cluster.discovery.consul.dispatcher` allows to set a custom dispatcher for actor working as discovery service. This is a common case in high-churn scenarios, when a noisy neighbors are slowing down time-sensitive operations of actors. Way to work with that is to define a [custom dispatcher](http://getakka.net/articles/actors/dispatchers.html) or use one of the preconfigured ones. This way a discovery service actor will get it's own resources - i.e. separate thread - to work on, aside of standard thread pool used by actors by default.

Related issue: #16