### PR TITLE
Hardening reconciliation

### DIFF
--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -29,7 +29,7 @@ namespace SampleApp
 			            provider = akka.cluster.discovery.consul
 			            consul {
 				            listener-url = ""http://127.0.0.1:8500""
-		                    refresh-interval = 1m
+		                    refresh-interval = 10s
 			            }
 		            }
 	            }");

--- a/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
@@ -52,13 +52,13 @@ namespace Akka.Cluster.Discovery.Consul
             await distributedLock.Release();
         }
 
-        protected override async Task<IEnumerable<Address>> GetAliveNodesAsync()
+        protected override async Task<IEnumerable<Address>> GetNodesAsync(bool onlyAlive)
         {
             var services = await consul.Health.Service(Context.System.Name);
 
             var result =
                 from x in services.Response
-                where Equals(x.Checks[1].Status, HealthStatus.Passing)
+                where !onlyAlive || Equals(x.Checks[1].Status, HealthStatus.Passing)
                 select Address.Parse(protocol + "://" + x.Service.ID);
 
             return result;

--- a/src/Akka.Cluster.Discovery/DiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery/DiscoveryService.cs
@@ -234,9 +234,9 @@ namespace Akka.Cluster.Discovery
             
             if (!provided.SetEquals(current))
             {
-                if (Log.IsInfoEnabled)
+                if (Log.IsWarningEnabled)
                 {
-                    Log.Info("Detected difference between set of nodes received from the discovery service [{0}] and the one provided by the cluster [{1}]",
+                    Log.Warning("Detected difference between set of nodes received from the discovery service [{0}] and the one provided by the cluster [{1}]. Downing nodes not present in discovery service.",
                         string.Join(", ", provided), string.Join(", ", current));
                 }
 

--- a/src/Akka.Cluster.Discovery/DiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery/DiscoveryService.cs
@@ -92,8 +92,9 @@ namespace Akka.Cluster.Discovery
         /// known as alive. If there are no alive nodes or cluster was not established
         /// yet, it returns an empty collections.
         /// </summary>
+        /// <param name="onlyAlive">Returns only nodes marked as alive.</param>
         /// <returns></returns>
-        protected abstract Task<IEnumerable<Address>> GetAliveNodesAsync();
+        protected abstract Task<IEnumerable<Address>> GetNodesAsync(bool onlyAlive);
 
         /// <summary>
         /// Registers provided <paramref name="node"/> inside of current service.
@@ -182,7 +183,7 @@ namespace Akka.Cluster.Discovery
 
         protected virtual async Task<bool> TryJoinAsync()
         {
-            var nodes = (await GetAliveNodesAsync()).ToArray();
+            var nodes = (await GetNodesAsync(onlyAlive: true)).ToArray();
             if (nodes.Length == 0)
                 Cluster.JoinSeedNodes(new[] {Entry.Address});
             else
@@ -217,7 +218,10 @@ namespace Akka.Cluster.Discovery
             ImmutableHashSet<Address> provided;
             try
             {
-                provided = (await GetAliveNodesAsync()).ToImmutableHashSet();
+                // try to get all nodes during reconciliation. It's acceptable to get unhealthy nodes
+                // if they didn't hit alive-timeout, as provdider service is expected to deregister
+                // nodes past that threshold - they won't appear here
+                provided = (await GetNodesAsync(onlyAlive: false)).ToImmutableHashSet();
             }
             catch (Exception e)
             {

--- a/src/Akka.Cluster.Discovery/reference.conf
+++ b/src/Akka.Cluster.Discovery/reference.conf
@@ -13,6 +13,9 @@ akka.cluster.discovery {
 		# used by the cluster discovery plugin.
 		class = "Akka.Cluster.Discovery.Consul.ConsulDiscoveryService, Akka.Cluster.Discovery.Consul"
 
+		# Define a dispatcher type used by discovery service actor.
+		dispatcher = "akka.actor.default-dispatcher"
+
 		# Time interval in which a `alive` signal will be send by a discovery service
 		# to fit the external service TTL (time to live) expectations. 
 		alive-interval = 5s


### PR DESCRIPTION
1. Changed reconciliation process to include unhealthy nodes during cluster discovery state reconciliation with cluster view state from Akka. This should be safe, as temporary unhealthy nodes are acceptable, while longer period of inactivity (past `active-timeout` threshold) should case 3rd party service to deregister the node, so it won't appear in queried set at all.
2. Increased log level for message marking difference detected during reconciliation from info to warning. This alert can be false, as right now result set taken from cluster discovery service is pretty permissive (due to pt.1), but it's better to inform than sorry.