### PR TITLE
Added restart-interval for consul client

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ akka.cluster.discovery {
 		# A timeout configured for consul to mark a time to live given for a node
 		# before it will be marked as unhealthy. Must be greater than `alive-interval` and less than `alive-timeout`.
 		service-check-ttl = 15s
+		
+		# An interval in which consul client will be triggered for periodic restarts. 
+		# If not provided or 0, client will never be restarted. 
+		restart-interval = 5m
 	}
 }
 ```

--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -30,6 +30,8 @@ namespace SampleApp
 			            consul {
 				            listener-url = ""http://127.0.0.1:8500""
 		                    refresh-interval = 10s
+                            # restart consul client every 5 minutes
+                            restart-interval = 5m
 			            }
 		            }
 	            }");

--- a/src/Akka.Cluster.Discovery.Consul/ConsulSettings.cs
+++ b/src/Akka.Cluster.Discovery.Consul/ConsulSettings.cs
@@ -20,10 +20,11 @@ namespace Akka.Cluster.Discovery.Consul
             Datacenter = config.GetString("datacenter");
             Token = config.GetString("token");
             WaitTime = !config.HasPath("wait-time") ? default(TimeSpan?) : config.GetTimeSpan("wait-time");
+            RestartInterval = !config.HasPath("restart-interval") ? default(TimeSpan?) : config.GetTimeSpan("restart-interval");
 
             var serviceCheckTtl = config.GetTimeSpan("service-check-ttl", new TimeSpan(this.AliveInterval.Ticks * 3));
             if (serviceCheckTtl < AliveInterval || serviceCheckTtl > AliveTimeout) throw new ArgumentException("`akka.cluster.discovery.consul.service-check-ttl` must greater than `akka.cluster.discovery.consul.alive-interval` and less than `akka.cluster.discovery.consul.alive-timeout`");
-
+            
             ServiceCheckTtl = serviceCheckTtl;
         }
 
@@ -34,6 +35,7 @@ namespace Akka.Cluster.Discovery.Consul
             Token = null;
             WaitTime = null;
             ServiceCheckTtl = new TimeSpan(this.AliveInterval.Ticks * 3);
+            RestartInterval = null;
         }
 
         public ConsulSettings(Uri listenerUrl,
@@ -45,7 +47,8 @@ namespace Akka.Cluster.Discovery.Consul
             TimeSpan refreshInterval,
             int joinRetries, 
             TimeSpan lockRetryInterval,
-            TimeSpan serviceCheckTtl) 
+            TimeSpan serviceCheckTtl,
+            TimeSpan? restartInterval) 
             : base(aliveInterval, aliveTimeout, refreshInterval, joinRetries, lockRetryInterval)
         {
             if (serviceCheckTtl < AliveInterval || serviceCheckTtl > AliveTimeout) throw new ArgumentException("serviceCheckTtl must greater than aliveInterval and less than aliveTimeout", nameof(serviceCheckTtl));
@@ -55,6 +58,7 @@ namespace Akka.Cluster.Discovery.Consul
             Token = token;
             WaitTime = waitTime;
             ServiceCheckTtl = serviceCheckTtl;
+            RestartInterval = restartInterval;
         }
 
         /// <summary>
@@ -82,5 +86,11 @@ namespace Akka.Cluster.Discovery.Consul
         /// marked as unhealthy. Must be greater than <see cref="AliveInterval"/> and less than <see cref="AliveTimeout"/>.
         /// </summary>
         public TimeSpan ServiceCheckTtl { get; }
+        
+        /// <summary>
+        /// An interval in which consul client will be triggered for periodic restarts.
+        /// If not provided or 0, client will never be restarted. Default value: null. 
+        /// </summary>
+        public TimeSpan? RestartInterval { get; }
     }
 }

--- a/src/Akka.Cluster.Discovery/reference.conf
+++ b/src/Akka.Cluster.Discovery/reference.conf
@@ -53,5 +53,9 @@ akka.cluster.discovery {
 
 		# Timeout for a Consul client connection requests.
 		#wait-time = <optional value>
+		
+		# An interval in which consul client will be triggered for periodic restarts. 
+		# If not provided or 0, client will never be restarted. 
+		#restart-interval = 0s
 	}
 }


### PR DESCRIPTION
PR to address #20 
I've got a suspicions about ability for Playfab consul client to work in long-running scenarios. To work around them, I've introduced `akka.cluster.discovery.consul.restart-interval` setting. When provided it will trigger periodic restart (disposal + recreation) of consul client.