### PR TITLE
reference.conf typo

### DIFF
--- a/src/Akka.Cluster.Discovery/reference.conf
+++ b/src/Akka.Cluster.Discovery/reference.conf
@@ -3,8 +3,8 @@ akka.cluster.discovery {
 	
 	# Path to a provider configuration used in for cluster discovery.
 	# Example:
-	# 1. akka.cluster.disovery.consul
-	provider = "akka.cluster.disovery.consul"
+	# 1. akka.cluster.discovery.consul
+	provider = "akka.cluster.discovery.consul"
 
 	# A configuration used by consult-based discovery service
 	consul {


### PR DESCRIPTION
provider = "akka.cluster.discovery.consul"
Otherwise throws NullReferenceException