### PR TITLE
Verify all Consul checks

### DIFF
--- a/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery.Consul/ConsulDiscoveryService.cs
@@ -98,7 +98,7 @@ namespace Akka.Cluster.Discovery.Consul
 
             var result =
                 from x in services.Response
-                where !onlyAlive || Equals(x.Checks[1].Status, HealthStatus.Passing)
+                where !onlyAlive || x.Checks.All(check => Equals(check.Status, HealthStatus.Passing))
                 select Address.Parse(protocol + "://" + x.Service.ID);
 
             return result;

--- a/src/Akka.Cluster.Discovery/DiscoveryService.cs
+++ b/src/Akka.Cluster.Discovery/DiscoveryService.cs
@@ -168,12 +168,12 @@ namespace Akka.Cluster.Discovery
                 {
                     if (retries > 0)
                     {
-                        Log.Error(cause, "Failed to obtain a distributed lock for actor system [{0}]. Remaining retries: [{1}]", Context.System.Name, retries);
+                        Log.Error(cause, "Failed to join actor system [{0}] to the cluster. Remaining retries: [{1}]", Context.System.Name, retries);
                         SendJoinSignal();
                     }
                     else
                     {
-                        Log.Error(cause, "Failed to obtain a distributed lock for actor system [{0}] after {1} retries. Closing.", Context.System.Name, settings.JoinRetries);
+                        Log.Error(cause, "Failed to join actor system [{0}] to the cluster after {1} retries. Closing.", Context.System.Name, settings.JoinRetries);
                         Context.Stop(Self);
                     }
                 }


### PR DESCRIPTION
Probably it's related to the same problem as https://github.com/Horusiath/Akka.Cluster.Discovery/issues/24

When Akka.Cluster.Discovery is unable to connect cluster if one of the instances do not have at least two checks assigned in Consul. When using older version of Consul a race condition may occur and lead to such situation - https://github.com/hashicorp/consul/issues/4998.

When there is such instance in Consul, new nodes trying to join will fail with IndexOutOfRangeException and the zombie instance has to be removed manually from Consul in order to allow new nodes to join.
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Akka.Cluster.Discovery.Consul.ConsulDiscoveryService.<>c__DisplayClass12_0.<GetNodesAsync>b__0(ServiceEntry x)
   at System.Linq.Enumerable.WhereSelectArrayIterator`2.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at Akka.Cluster.Discovery.DiscoveryService.TryJoinAsync()
   at Akka.Cluster.Discovery.LockingDiscoveryService.TryJoinAsync()
   at Akka.Cluster.Discovery.LockingDiscoveryService.TryJoinAsync()
   at Akka.Cluster.Discovery.DiscoveryService.<>c__DisplayClass16_1.<<-ctor>b__1>d.MoveNext()
````

My proposal is to verify all checks of the when filtering instances to be used as seed nodes. My problem was mainly caused by outdated Consul but anyway expecting an array returned by Consul to have at least two elements seems risky. 

Taking other healthchecks into account can be also beneficial if one of consul agents would go down in not graceful way - application instance would still appear in catalog with passing TTL check and failing serfHealth (looks like DeregisterCriticalServiceAfter is not taken into account in such scenario) - in current implementation it would be considered as a healthy instance.

If I'm missing something and we should't rely on serfHealth - maybe we should at least verify number of elements in checks array? I would change my PR then.

By the way, I've changed message of excetpion thrown in DiscoveryService.cs - it wasn't necessarly an issue with obtaining lock.